### PR TITLE
Listen on port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       dockerfile: Dockerfile
     container_name: ip-tools
     ports:
-      - "8080:80"
+      - "80:80"
     healthcheck:
-      test: curl --fail -s http://localhost:8080/index.php || exit 1
+      test: curl --fail -s http://localhost/index.php || exit 1
       interval: 1m30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Before this container was configured to listen on port 8080, this change makes it listen on port 80 instead.