### PR TITLE
Renamed video page

### DIFF
--- a/navBar.php
+++ b/navBar.php
@@ -31,7 +31,7 @@
         <a href="source.php" title="Source Code">Source Code</a>
     </li>
     <li>
-        <a href="mystery.php" title="Mystery Link">Mystery Link</a>
+        <a href="video.php" title="Video">HTML5 Video</a>
     </li>
 </ul>
 

--- a/video.php
+++ b/video.php
@@ -8,7 +8,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>Trololo</title>
+        <title>Elephants Dream</title>
         <script src="https://jwpsrv.com/library/3ADBggl8EeSvuyIACtqXBA.js"></script>
         <link rel="stylesheet" type="text/css" href="style.css">
 
@@ -20,7 +20,6 @@
         include("navBar.php"); 
         ?>
 
-        <!--Play the funky music white boi-->
         <div id ='main'>
             <div id='playerAbAaKnKdHGmU'></div>
             <script type='text/javascript'>


### PR DESCRIPTION
Before, the video page was named mystery link which was deceptive. Now it is named HTML5 video, which is a better name for it.

Also removed some unnecessary comments.